### PR TITLE
Fix deprecation warning - import TextIO from typing directly

### DIFF
--- a/pyshexc/parser/ShExDocLexer.py
+++ b/pyshexc/parser/ShExDocLexer.py
@@ -1,7 +1,7 @@
 # Generated from ShExDoc.g4 by ANTLR 4.9
 from antlr4 import *
 from io import StringIO
-from typing.io import TextIO
+from typing import TextIO
 import sys
 
 


### PR DESCRIPTION
Any downstream package that uses this one get an annoying deprecation warning when running tests (and also ig can't use this with python3.12)

```
pyshexc/parser/ShExDocLexer.py:4: in <module>
    from typing.io import TextIO
../../../.pyenv/versions/3.11.3/lib/python3.11/typing.py:3303: in __getattribute__
    warnings.warn(
E   DeprecationWarning: typing.io is deprecated, import directly from typing instead. typing.io will be removed in Python 3.12.
```

so this just does that.